### PR TITLE
feat(#53): Integrate Contentful for Services Tab copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     ]
   },
   "dependencies": {
+    "@contentful/rich-text-react-renderer": "^16.1.6",
     "@tailwindcss/typography": "^0.5.16",
     "clsx": "^2.1.1",
     "contentful": "^11.7.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@contentful/rich-text-react-renderer':
+        specifier: ^16.1.6
+        version: 16.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.19(tailwindcss@3.4.18(yaml@2.8.2))
@@ -253,8 +256,19 @@ packages:
   '@contentful/content-source-maps@0.11.43':
     resolution: {integrity: sha512-2FHAjtre+lc3EXMqrZh97vA/kIDVdu2eHyRj/yaXPKtacP0qCA7lPE1QvMaZeKqZkP6i3afY0WyeKoX4Y5eRlg==}
 
+  '@contentful/rich-text-react-renderer@16.1.6':
+    resolution: {integrity: sha512-Pt0KfEnB7UP53gUKupUZjsUCHR7CiDbVyMdMmuyzYT6lNvjR7+KKYWP9eU2TOfVaXy7PxF1XEpBjSALDOHUNKQ==}
+    engines: {node: '>=6.0.0'}
+    peerDependencies:
+      react: ^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@contentful/rich-text-types@16.8.5':
     resolution: {integrity: sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==}
+    engines: {node: '>=6.0.0'}
+
+  '@contentful/rich-text-types@17.2.5':
+    resolution: {integrity: sha512-EA5vTfROZePoPmSlqLVd+luL/ev8CjnI20y6vWFVPlLRxQbv4XytXRzatydPE63CqfsPylF7NCn2z8rTLhnWfg==}
     engines: {node: '>=6.0.0'}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -857,6 +871,22 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@lingui/core@5.9.1':
+    resolution: {integrity: sha512-gnrh3YMo3yGI7NrYvVL5vtIap2fPahl2OAR0P9Fl/eW6GFPUGhhjIcxqxAg48/Nd4lTAzBCGwPCP+u2DzAIzEA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@lingui/babel-plugin-lingui-macro': 5.9.1
+      babel-plugin-macros: 2 || 3
+    peerDependenciesMeta:
+      '@lingui/babel-plugin-lingui-macro':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  '@lingui/message-utils@5.9.1':
+    resolution: {integrity: sha512-2hj2PqHQU7hI+2+JiViOPmeTmms/8Xl1i/AWd59hwaf+lbqDFKc8CmeZNeAvrM+D7FeYgX1/mDoQvWAkLZNYjQ==}
+    engines: {node: '>=20.0.0'}
+
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
@@ -865,6 +895,9 @@ packages:
     resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@messageformat/parser@5.1.1':
+    resolution: {integrity: sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==}
 
   '@netlify/ai@0.3.3':
     resolution: {integrity: sha512-P2EWy+fmybtJ4xptqR1qq+fL0JK4kj7MxqziSIB9BfqG7kIGDPTHHgbrzpEbgNvUpPt/l74mF5rQ5UW26VRp3A==}
@@ -4395,6 +4428,9 @@ packages:
   js-image-generator@1.0.4:
     resolution: {integrity: sha512-ckb7kyVojGAnArouVR+5lBIuwU1fcrn7E/YYSd0FK7oIngAkMmRvHASLro9Zt5SQdWToaI66NybG+OGxPw/HlQ==}
 
+  js-sha256@0.10.1:
+    resolution: {integrity: sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4849,6 +4885,9 @@ packages:
   moize@6.1.7:
     resolution: {integrity: sha512-8/9XgYooMo7/q5tf6zGF4+Wp1jx5sbxV87uK6YvTq9rgDtusLWZCZ8c5C0EhYZbNGudul5EMeMsObO4Ug/gszg==}
     deprecated: This library has been deprecated in favor of micro-memoize, which as-of version 5 incorporates most of the functionality that this library offers at nearly half the size and better speed.
+
+  moo@0.5.2:
+    resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
 
   move-file@3.1.0:
     resolution: {integrity: sha512-4aE3U7CCBWgrQlQDMq8da4woBWDGHioJFiOZ8Ie6Yq2uwYQ9V2kGhTz4x3u6Wc+OU17nw0yc3rJ/lQ4jIiPe3A==}
@@ -7168,7 +7207,24 @@ snapshots:
       '@vercel/stega': 0.1.2
       json-pointer: 0.6.2
 
+  '@contentful/rich-text-react-renderer@16.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@contentful/rich-text-types': 17.2.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@lingui/babel-plugin-lingui-macro'
+      - babel-plugin-macros
+
   '@contentful/rich-text-types@16.8.5': {}
+
+  '@contentful/rich-text-types@17.2.5':
+    dependencies:
+      '@lingui/core': 5.9.1
+      is-plain-obj: 3.0.0
+    transitivePeerDependencies:
+      - '@lingui/babel-plugin-lingui-macro'
+      - babel-plugin-macros
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -7593,6 +7649,16 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@lingui/core@5.9.1':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@lingui/message-utils': 5.9.1
+
+  '@lingui/message-utils@5.9.1':
+    dependencies:
+      '@messageformat/parser': 5.1.1
+      js-sha256: 0.10.1
+
   '@lukeed/ms@2.0.2': {}
 
   '@mapbox/node-pre-gyp@2.0.3(supports-color@10.2.2)':
@@ -7607,6 +7673,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@messageformat/parser@5.1.1':
+    dependencies:
+      moo: 0.5.2
 
   '@netlify/ai@0.3.3(@netlify/api@14.0.11)':
     dependencies:
@@ -11673,6 +11743,8 @@ snapshots:
     dependencies:
       jpeg-js: 0.4.4
 
+  js-sha256@0.10.1: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -12140,6 +12212,8 @@ snapshots:
     dependencies:
       fast-equals: 3.0.3
       micro-memoize: 4.2.0
+
+  moo@0.5.2: {}
 
   move-file@3.1.0:
     dependencies:

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -92,7 +92,12 @@ const ServiceDescription = ({ description, className }) => {
   // Rich Text document from Contentful has a nodeType property
   if (typeof description === 'object' && description.nodeType) {
     return (
-      <div className={clsx('opacity-90 prose prose-sm max-w-none', className)}>
+      <div
+        className={clsx(
+          'opacity-90 prose prose-sm max-w-none dark:prose-invert catppuccin:prose-invert',
+          className
+        )}
+      >
         {documentToReactComponents(description)}
       </div>
     );

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -40,8 +40,51 @@ const fallbackServices = [
 ];
 
 /**
+ * Theme-specific Tailwind class bundles for service card elements.
+ * Extracts repeated theme logic from inline JSX expressions.
+ */
+const LEGACY_THEMES = ['dark', 'light', 'rosepine'];
+
+export const getServiceCardClasses = theme => {
+  if (theme === 'flexoki')
+    return 'bg-flexoki-surface border-flexoki-surface text-flexoki-text';
+  if (theme === 'matrix')
+    return 'bg-matrix-terminal border-matrix-glow text-matrix-glow shadow-[0_0_10px_rgba(0,255,0,0.1)]';
+  if (theme === 'web2')
+    return 'bg-web2-background border-web2-border shadow-sm';
+  // catppuccin + legacy themes all map to catppuccin styles
+  return 'bg-catppuccin-surface border-catppuccin-surface text-catppuccin-text';
+};
+
+export const getServiceIconClasses = theme => {
+  if (theme === 'flexoki') return 'text-flexoki-cyan';
+  if (theme === 'matrix') return 'text-matrix-glow';
+  if (theme === 'web2') return 'text-web2-primary';
+  return 'text-catppuccin-blue';
+};
+
+export const getServiceCtaBorderClasses = theme => {
+  if (theme === 'flexoki') return 'border-flexoki-cyan/30 text-flexoki-text';
+  if (theme === 'matrix') return 'border-matrix-glow/30 text-matrix-glow';
+  if (theme === 'web2') return 'border-web2-primary/30 text-web2-text';
+  return 'border-catppuccin-blue/30 text-catppuccin-text';
+};
+
+export const getServiceCtaButtonClasses = theme => {
+  if (theme === 'flexoki') return 'bg-flexoki-cyan text-flexoki-base';
+  if (theme === 'matrix')
+    return 'bg-matrix-glow text-matrix-terminal shadow-[0_0_15px_#0f0]';
+  if (theme === 'web2') return 'bg-web2-primary text-white';
+  return 'bg-catppuccin-blue text-catppuccin-base';
+};
+
+/**
  * Render a description field that may be a Contentful Rich Text document
  * or a plain string (from fallback data).
+ *
+ * Fix: Removed conflicting `text-base leading-relaxed` from the rich-text
+ * path — `prose prose-sm` already sets its own font-size and line-height,
+ * and mixing them caused override conflicts.
  */
 const ServiceDescription = ({ description, className }) => {
   if (!description) return null;
@@ -49,12 +92,7 @@ const ServiceDescription = ({ description, className }) => {
   // Rich Text document from Contentful has a nodeType property
   if (typeof description === 'object' && description.nodeType) {
     return (
-      <div
-        className={clsx(
-          'text-base leading-relaxed opacity-90 prose prose-sm max-w-none',
-          className
-        )}
-      >
+      <div className={clsx('opacity-90 prose prose-sm max-w-none', className)}>
         {documentToReactComponents(description)}
       </div>
     );
@@ -92,25 +130,13 @@ const Services = ({ theme = 'catppuccin' }) => {
 
       {!loading && (
         <div className="grid gap-6 grid-cols-1">
-          {sortedServices.map(service => (
+          {sortedServices.map((service, index) => (
             <div
-              key={service.id || service.title}
+              key={service.id || `service-${index}`}
               className={clsx(
                 'p-6 rounded-lg border transition-all duration-300',
                 'hover:scale-[1.01]',
-                theme === 'catppuccin' &&
-                  'bg-catppuccin-surface border-catppuccin-surface text-catppuccin-text',
-                theme === 'flexoki' &&
-                  'bg-flexoki-surface border-flexoki-surface text-flexoki-text',
-                theme === 'matrix' &&
-                  'bg-matrix-terminal border-matrix-glow text-matrix-glow shadow-[0_0_10px_rgba(0,255,0,0.1)]',
-                theme === 'web2' &&
-                  'bg-web2-background border-web2-border shadow-sm',
-                // Fallback for deprecated or unknown themes
-                (theme === 'dark' ||
-                  theme === 'light' ||
-                  theme === 'rosepine') &&
-                  'bg-catppuccin-surface border-catppuccin-surface text-catppuccin-text'
+                getServiceCardClasses(theme)
               )}
             >
               <div className="flex items-center gap-3 mb-3">
@@ -118,16 +144,7 @@ const Services = ({ theme = 'catppuccin' }) => {
                   <DynamicIcon
                     iconName={service.icon}
                     size={24}
-                    className={clsx(
-                      theme === 'catppuccin' && 'text-catppuccin-blue',
-                      theme === 'flexoki' && 'text-flexoki-cyan',
-                      theme === 'matrix' && 'text-matrix-glow',
-                      theme === 'web2' && 'text-web2-primary',
-                      (theme === 'dark' ||
-                        theme === 'light' ||
-                        theme === 'rosepine') &&
-                        'text-catppuccin-blue'
-                    )}
+                    className={getServiceIconClasses(theme)}
                   />
                 )}
                 <div>
@@ -156,13 +173,7 @@ const Services = ({ theme = 'catppuccin' }) => {
       <div
         className={clsx(
           'mt-8 p-6 rounded-xl text-center border-2 border-dashed',
-          theme === 'catppuccin' &&
-            'border-catppuccin-blue/30 text-catppuccin-text',
-          theme === 'flexoki' && 'border-flexoki-cyan/30 text-flexoki-text',
-          theme === 'matrix' && 'border-matrix-glow/30 text-matrix-glow',
-          theme === 'web2' && 'border-web2-primary/30 text-web2-text',
-          (theme === 'dark' || theme === 'light' || theme === 'rosepine') &&
-            'border-catppuccin-blue/30 text-catppuccin-text'
+          getServiceCtaBorderClasses(theme)
         )}
       >
         <p className="text-lg font-bold mb-2">
@@ -172,13 +183,7 @@ const Services = ({ theme = 'catppuccin' }) => {
           href="mailto:ulises@luxspark.com"
           className={clsx(
             'inline-block px-6 py-2 rounded-full font-bold transition-transform hover:scale-105',
-            theme === 'catppuccin' && 'bg-catppuccin-blue text-catppuccin-base',
-            theme === 'flexoki' && 'bg-flexoki-cyan text-flexoki-base',
-            theme === 'matrix' &&
-              'bg-matrix-glow text-matrix-terminal shadow-[0_0_15px_#0f0]',
-            theme === 'web2' && 'bg-web2-primary text-white',
-            (theme === 'dark' || theme === 'light' || theme === 'rosepine') &&
-              'bg-catppuccin-blue text-catppuccin-base'
+            getServiceCtaButtonClasses(theme)
           )}
         >
           Book a Consultation

--- a/src/components/Services.jsx
+++ b/src/components/Services.jsx
@@ -1,91 +1,158 @@
 import clsx from 'clsx';
+import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
 import SectionHeading from './SectionHeading';
 import DynamicIcon from './DynamicIcon';
+import { useContentful } from '../hooks/useContentful';
+import { getServices } from '../utils/contentful';
 
-const services = [
+// Fallback data for when Contentful is unavailable
+const fallbackServices = [
   {
+    id: '1',
     title: 'The Sovereign Protocol',
     subtitle: 'OpenClaw & Agentic Environments',
     description:
       'Building robust, personal agentic architectures. I specialize in OpenClaw orchestration, Taskwarrior integration, and long-term memory gardening to turn LLMs into true autonomous familiars.',
     icon: 'FaUserShield',
+    order: 1,
+    active: true,
   },
   {
+    id: '2',
     title: 'Dev-Partner Coaching',
     subtitle: 'The Buffalo Bridle Approach',
     description:
       'Tutoring for non-coders and founders. Learn how to partner with LLMs to ship high-quality products without getting lost in the syntax. We focus on strategic leverage and mental models.',
     icon: 'FaUserTie',
+    order: 2,
+    active: true,
   },
   {
+    id: '3',
     title: 'Agentic Product Rescue',
     subtitle: 'Modernizing Legacy Monoliths',
     description:
       'Unblocking stale projects and legacy codebases using enterprise experience coupled with modern agentic workflows to accelerate delivery and ensure system continuity.',
     icon: 'FaLifeRing',
+    order: 3,
+    active: true,
   },
 ];
 
+/**
+ * Render a description field that may be a Contentful Rich Text document
+ * or a plain string (from fallback data).
+ */
+const ServiceDescription = ({ description, className }) => {
+  if (!description) return null;
+
+  // Rich Text document from Contentful has a nodeType property
+  if (typeof description === 'object' && description.nodeType) {
+    return (
+      <div
+        className={clsx(
+          'text-base leading-relaxed opacity-90 prose prose-sm max-w-none',
+          className
+        )}
+      >
+        {documentToReactComponents(description)}
+      </div>
+    );
+  }
+
+  // Plain string (fallback data)
+  return (
+    <p className={clsx('text-base leading-relaxed opacity-90', className)}>
+      {description}
+    </p>
+  );
+};
+
 const Services = ({ theme = 'catppuccin' }) => {
+  const { data: cmsServices, loading, error } = useContentful(getServices);
+
+  const services =
+    cmsServices && cmsServices.length > 0 ? cmsServices : fallbackServices;
+
+  const sortedServices = [...services]
+    .filter(s => s.active)
+    .sort((a, b) => a.order - b.order);
+
+  if (error) {
+    console.warn('Contentful error, using fallback services data:', error);
+  }
+
   return (
     <section className={clsx('p-5 animate-fade-in')}>
       <SectionHeading>Services</SectionHeading>
-      <div className="grid gap-6 grid-cols-1">
-        {services.map(service => (
-          <div
-            key={service.title}
-            className={clsx(
-              'p-6 rounded-lg border transition-all duration-300',
-              'hover:scale-[1.01]',
-              theme === 'catppuccin' &&
-                'bg-catppuccin-surface border-catppuccin-surface text-catppuccin-text',
-              theme === 'flexoki' &&
-                'bg-flexoki-surface border-flexoki-surface text-flexoki-text',
-              theme === 'matrix' &&
-                'bg-matrix-terminal border-matrix-glow text-matrix-glow shadow-[0_0_10px_rgba(0,255,0,0.1)]',
-              theme === 'web2' &&
-                'bg-web2-background border-web2-border shadow-sm',
-              // Fallback for deprecated or unknown themes
-              (theme === 'dark' || theme === 'light' || theme === 'rosepine') &&
-                'bg-catppuccin-surface border-catppuccin-surface text-catppuccin-text'
-            )}
-          >
-            <div className="flex items-center gap-3 mb-3">
-              <DynamicIcon
-                iconName={service.icon}
-                size={24}
-                className={clsx(
-                  theme === 'catppuccin' && 'text-catppuccin-blue',
-                  theme === 'flexoki' && 'text-flexoki-cyan',
-                  theme === 'matrix' && 'text-matrix-glow',
-                  theme === 'web2' && 'text-web2-primary',
-                  (theme === 'dark' ||
-                    theme === 'light' ||
-                    theme === 'rosepine') &&
-                    'text-catppuccin-blue'
-                )}
-              />
-              <div>
-                <h3 className="text-xl font-bold leading-tight">
-                  {service.title}
-                </h3>
-                <p
-                  className={clsx(
-                    'text-sm font-medium opacity-80',
-                    theme === 'matrix' && 'text-matrix-rain'
-                  )}
-                >
-                  {service.subtitle}
-                </p>
-              </div>
-            </div>
-            <p className="text-base leading-relaxed opacity-90">
-              {service.description}
-            </p>
-          </div>
-        ))}
-      </div>
 
+      {loading && (
+        <div className="text-center py-8 opacity-60">Loading services...</div>
+      )}
+
+      {!loading && (
+        <div className="grid gap-6 grid-cols-1">
+          {sortedServices.map(service => (
+            <div
+              key={service.id || service.title}
+              className={clsx(
+                'p-6 rounded-lg border transition-all duration-300',
+                'hover:scale-[1.01]',
+                theme === 'catppuccin' &&
+                  'bg-catppuccin-surface border-catppuccin-surface text-catppuccin-text',
+                theme === 'flexoki' &&
+                  'bg-flexoki-surface border-flexoki-surface text-flexoki-text',
+                theme === 'matrix' &&
+                  'bg-matrix-terminal border-matrix-glow text-matrix-glow shadow-[0_0_10px_rgba(0,255,0,0.1)]',
+                theme === 'web2' &&
+                  'bg-web2-background border-web2-border shadow-sm',
+                // Fallback for deprecated or unknown themes
+                (theme === 'dark' ||
+                  theme === 'light' ||
+                  theme === 'rosepine') &&
+                  'bg-catppuccin-surface border-catppuccin-surface text-catppuccin-text'
+              )}
+            >
+              <div className="flex items-center gap-3 mb-3">
+                {service.icon && (
+                  <DynamicIcon
+                    iconName={service.icon}
+                    size={24}
+                    className={clsx(
+                      theme === 'catppuccin' && 'text-catppuccin-blue',
+                      theme === 'flexoki' && 'text-flexoki-cyan',
+                      theme === 'matrix' && 'text-matrix-glow',
+                      theme === 'web2' && 'text-web2-primary',
+                      (theme === 'dark' ||
+                        theme === 'light' ||
+                        theme === 'rosepine') &&
+                        'text-catppuccin-blue'
+                    )}
+                  />
+                )}
+                <div>
+                  <h3 className="text-xl font-bold leading-tight">
+                    {service.title}
+                  </h3>
+                  {service.subtitle && (
+                    <p
+                      className={clsx(
+                        'text-sm font-medium opacity-80',
+                        theme === 'matrix' && 'text-matrix-rain'
+                      )}
+                    >
+                      {service.subtitle}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <ServiceDescription description={service.description} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* CTA — intentionally hardcoded */}
       <div
         className={clsx(
           'mt-8 p-6 rounded-xl text-center border-2 border-dashed',

--- a/src/index.css
+++ b/src/index.css
@@ -105,7 +105,9 @@
            dark:text-dracula-foreground
            web2:text-web2-primaryDark
            matrix:text-matrix-text
-           xmas:text-xmas-gold;
+           xmas:text-xmas-gold
+           catppuccin:text-catppuccin-blue
+           flexoki:text-flexoki-cyan;
   }
 
   body.matrix-bg {

--- a/src/utils/contentful.js
+++ b/src/utils/contentful.js
@@ -198,6 +198,27 @@ export const getSoundCloudTrack = async () => {
   }
 };
 
+export const getServices = async () => {
+  try {
+    const response = await client.getEntries({
+      content_type: 'service',
+      order: 'fields.order',
+    });
+    return response.items.map(item => ({
+      id: item.sys.id,
+      title: item.fields.title,
+      subtitle: item.fields.subtitle || '',
+      description: item.fields.description,
+      icon: item.fields.icon || null,
+      order: item.fields.order || 0,
+      active: item.fields.active !== false,
+    }));
+  } catch (error) {
+    console.error('Error fetching services:', error);
+    return [];
+  }
+};
+
 export const getBio = async () => {
   try {
     const response = await client.getEntries({

--- a/test/components/Services.test.jsx
+++ b/test/components/Services.test.jsx
@@ -1,0 +1,490 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Services from '../../src/components/Services';
+import {
+  getServiceCardClasses,
+  getServiceIconClasses,
+  getServiceCtaBorderClasses,
+  getServiceCtaButtonClasses,
+} from '../../src/components/Services';
+import * as useContentfulHook from '../../src/hooks/useContentful';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('../../src/hooks/useContentful');
+
+vi.mock('../../src/components/DynamicIcon', () => ({
+  default: ({ iconName, size }) => (
+    <span data-testid="dynamic-icon" data-icon={iconName} data-size={size}>
+      {iconName}
+    </span>
+  ),
+}));
+
+vi.mock('../../src/utils/contentful', () => ({
+  getServices: vi.fn(),
+}));
+
+// Mock rich-text renderer so tests don't need Contentful internals
+vi.mock('@contentful/rich-text-react-renderer', () => ({
+  documentToReactComponents: doc => (
+    <span data-testid="rich-text">
+      {doc?.content?.[0]?.value ?? 'rich text'}
+    </span>
+  ),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const mockLoading = () =>
+  useContentfulHook.useContentful.mockReturnValue({
+    data: null,
+    loading: true,
+    error: null,
+  });
+
+const mockError = err =>
+  useContentfulHook.useContentful.mockReturnValue({
+    data: null,
+    loading: false,
+    error: err,
+  });
+
+const mockData = data =>
+  useContentfulHook.useContentful.mockReturnValue({
+    data,
+    loading: false,
+    error: null,
+  });
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Services', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Loading & error states ──────────────────────────────────────────────
+
+  it('renders the section heading', () => {
+    mockLoading();
+    render(<Services theme="catppuccin" />);
+    expect(screen.getByText('Services')).toBeInTheDocument();
+  });
+
+  it('renders loading state', () => {
+    mockLoading();
+    render(<Services theme="catppuccin" />);
+    expect(screen.getByText('Loading services...')).toBeInTheDocument();
+  });
+
+  it('logs warning and shows fallback data on Contentful error', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockError(new Error('Contentful down'));
+
+    render(<Services theme="catppuccin" />);
+
+    expect(warnSpy).toHaveBeenCalled();
+    // Fallback services should be visible
+    expect(screen.getByText('The Sovereign Protocol')).toBeInTheDocument();
+    warnSpy.mockRestore();
+  });
+
+  // ── Fallback data ───────────────────────────────────────────────────────
+
+  it('renders fallback services when CMS returns null', () => {
+    mockData(null);
+    render(<Services theme="catppuccin" />);
+    expect(screen.getByText('The Sovereign Protocol')).toBeInTheDocument();
+    expect(screen.getByText('Dev-Partner Coaching')).toBeInTheDocument();
+    expect(screen.getByText('Agentic Product Rescue')).toBeInTheDocument();
+  });
+
+  it('renders fallback services when CMS returns empty array', () => {
+    mockData([]);
+    render(<Services theme="catppuccin" />);
+    expect(screen.getByText('The Sovereign Protocol')).toBeInTheDocument();
+  });
+
+  // ── CMS data ────────────────────────────────────────────────────────────
+
+  it('renders CMS services when provided', () => {
+    const cmsServices = [
+      {
+        id: 'cms-1',
+        title: 'CMS Service One',
+        subtitle: 'Sub One',
+        description: 'Desc one',
+        icon: 'FaRocket',
+        order: 1,
+        active: true,
+      },
+      {
+        id: 'cms-2',
+        title: 'CMS Service Two',
+        subtitle: 'Sub Two',
+        description: 'Desc two',
+        icon: 'FaStar',
+        order: 2,
+        active: true,
+      },
+    ];
+    mockData(cmsServices);
+    render(<Services theme="catppuccin" />);
+    expect(screen.getByText('CMS Service One')).toBeInTheDocument();
+    expect(screen.getByText('CMS Service Two')).toBeInTheDocument();
+  });
+
+  it('filters out inactive CMS services', () => {
+    const cmsServices = [
+      {
+        id: 'a',
+        title: 'Active Service',
+        subtitle: '',
+        description: 'Active',
+        icon: null,
+        order: 1,
+        active: true,
+      },
+      {
+        id: 'b',
+        title: 'Inactive Service',
+        subtitle: '',
+        description: 'Inactive',
+        icon: null,
+        order: 2,
+        active: false,
+      },
+    ];
+    mockData(cmsServices);
+    render(<Services theme="catppuccin" />);
+    expect(screen.getByText('Active Service')).toBeInTheDocument();
+    expect(screen.queryByText('Inactive Service')).not.toBeInTheDocument();
+  });
+
+  it('sorts CMS services by order ascending', () => {
+    const cmsServices = [
+      {
+        id: 'c',
+        title: 'Third',
+        subtitle: '',
+        description: '',
+        icon: null,
+        order: 3,
+        active: true,
+      },
+      {
+        id: 'a',
+        title: 'First',
+        subtitle: '',
+        description: '',
+        icon: null,
+        order: 1,
+        active: true,
+      },
+      {
+        id: 'b',
+        title: 'Second',
+        subtitle: '',
+        description: '',
+        icon: null,
+        order: 2,
+        active: true,
+      },
+    ];
+    mockData(cmsServices);
+    render(<Services theme="catppuccin" />);
+
+    const headings = screen.getAllByRole('heading', { level: 3 });
+    const texts = headings.map(h => h.textContent);
+    expect(texts).toEqual(['First', 'Second', 'Third']);
+  });
+
+  // ── Unique keys (regression for duplicate key fix) ──────────────────────
+
+  it('renders services without React key warnings when ids are present', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const cmsServices = [
+      {
+        id: 'u1',
+        title: 'Unique A',
+        subtitle: '',
+        description: '',
+        icon: null,
+        order: 1,
+        active: true,
+      },
+      {
+        id: 'u2',
+        title: 'Unique B',
+        subtitle: '',
+        description: '',
+        icon: null,
+        order: 2,
+        active: true,
+      },
+    ];
+    mockData(cmsServices);
+    render(<Services theme="catppuccin" />);
+    // No 'Each child in a list should have a unique "key"' errors expected
+    const keyWarning = errSpy.mock.calls.find(args =>
+      String(args[0]).includes('unique "key"')
+    );
+    expect(keyWarning).toBeUndefined();
+    errSpy.mockRestore();
+  });
+
+  it('uses index-based fallback key when service id is missing', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const cmsServices = [
+      {
+        id: undefined,
+        title: 'No ID A',
+        subtitle: '',
+        description: '',
+        icon: null,
+        order: 1,
+        active: true,
+      },
+      {
+        id: undefined,
+        title: 'No ID B',
+        subtitle: '',
+        description: '',
+        icon: null,
+        order: 2,
+        active: true,
+      },
+    ];
+    mockData(cmsServices);
+    render(<Services theme="catppuccin" />);
+    expect(screen.getByText('No ID A')).toBeInTheDocument();
+    expect(screen.getByText('No ID B')).toBeInTheDocument();
+    // Should still render without key duplicate errors
+    const keyWarning = errSpy.mock.calls.find(args =>
+      String(args[0]).includes('unique "key"')
+    );
+    expect(keyWarning).toBeUndefined();
+    errSpy.mockRestore();
+  });
+
+  // ── Icons & subtitles ───────────────────────────────────────────────────
+
+  it('renders DynamicIcon when service has an icon', () => {
+    const cmsServices = [
+      {
+        id: 'i1',
+        title: 'Icon Service',
+        subtitle: 'Sub',
+        description: 'Desc',
+        icon: 'FaBolt',
+        order: 1,
+        active: true,
+      },
+    ];
+    mockData(cmsServices);
+    render(<Services theme="catppuccin" />);
+    expect(screen.getByTestId('dynamic-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('dynamic-icon')).toHaveAttribute(
+      'data-icon',
+      'FaBolt'
+    );
+  });
+
+  it('does not render icon element when service has no icon', () => {
+    const cmsServices = [
+      {
+        id: 'n1',
+        title: 'No Icon',
+        subtitle: '',
+        description: 'Desc',
+        icon: null,
+        order: 1,
+        active: true,
+      },
+    ];
+    mockData(cmsServices);
+    render(<Services theme="catppuccin" />);
+    expect(screen.queryByTestId('dynamic-icon')).not.toBeInTheDocument();
+  });
+
+  it('renders subtitle when provided', () => {
+    const cmsServices = [
+      {
+        id: 's1',
+        title: 'Has Subtitle',
+        subtitle: 'My Subtitle',
+        description: 'Desc',
+        icon: null,
+        order: 1,
+        active: true,
+      },
+    ];
+    mockData(cmsServices);
+    render(<Services theme="catppuccin" />);
+    expect(screen.getByText('My Subtitle')).toBeInTheDocument();
+  });
+
+  // ── Rich text description ────────────────────────────────────────────────
+
+  it('renders rich text description for Contentful document objects', () => {
+    const richTextDoc = {
+      nodeType: 'document',
+      content: [{ value: 'Rich text content here' }],
+    };
+    const cmsServices = [
+      {
+        id: 'rt1',
+        title: 'Rich Text Service',
+        subtitle: '',
+        description: richTextDoc,
+        icon: null,
+        order: 1,
+        active: true,
+      },
+    ];
+    mockData(cmsServices);
+    render(<Services theme="catppuccin" />);
+    expect(screen.getByTestId('rich-text')).toBeInTheDocument();
+    expect(screen.getByTestId('rich-text').textContent).toBe(
+      'Rich text content here'
+    );
+  });
+
+  it('renders plain string description as a paragraph', () => {
+    mockData(null); // use fallback data which has string descriptions
+    render(<Services theme="catppuccin" />);
+    // Fallback descriptions are plain strings rendered as <p> tags
+    const para = screen.getAllByText(
+      /Building robust, personal agentic architectures/i
+    )[0];
+    expect(para.tagName).toBe('P');
+  });
+
+  // ── CTA section ─────────────────────────────────────────────────────────
+
+  it('renders the CTA booking link', () => {
+    mockData(null);
+    render(<Services theme="catppuccin" />);
+    const link = screen.getByRole('link', { name: /Book a Consultation/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'mailto:ulises@luxspark.com');
+  });
+
+  // ── Theme helpers ────────────────────────────────────────────────────────
+
+  describe('getServiceCardClasses', () => {
+    it('returns catppuccin classes for catppuccin theme', () => {
+      expect(getServiceCardClasses('catppuccin')).toContain(
+        'bg-catppuccin-surface'
+      );
+    });
+
+    it('returns flexoki classes for flexoki theme', () => {
+      expect(getServiceCardClasses('flexoki')).toContain('bg-flexoki-surface');
+    });
+
+    it('returns matrix classes for matrix theme', () => {
+      expect(getServiceCardClasses('matrix')).toContain('bg-matrix-terminal');
+    });
+
+    it('returns web2 classes for web2 theme', () => {
+      expect(getServiceCardClasses('web2')).toContain('bg-web2-background');
+    });
+
+    it('falls back to catppuccin for legacy dark theme', () => {
+      expect(getServiceCardClasses('dark')).toContain('bg-catppuccin-surface');
+    });
+
+    it('falls back to catppuccin for legacy light theme', () => {
+      expect(getServiceCardClasses('light')).toContain('bg-catppuccin-surface');
+    });
+
+    it('falls back to catppuccin for legacy rosepine theme', () => {
+      expect(getServiceCardClasses('rosepine')).toContain(
+        'bg-catppuccin-surface'
+      );
+    });
+
+    it('falls back to catppuccin for unknown theme', () => {
+      expect(getServiceCardClasses('unknown')).toContain(
+        'bg-catppuccin-surface'
+      );
+    });
+  });
+
+  describe('getServiceIconClasses', () => {
+    it('returns catppuccin-blue for catppuccin theme', () => {
+      expect(getServiceIconClasses('catppuccin')).toContain(
+        'text-catppuccin-blue'
+      );
+    });
+
+    it('returns flexoki-cyan for flexoki theme', () => {
+      expect(getServiceIconClasses('flexoki')).toContain('text-flexoki-cyan');
+    });
+
+    it('returns matrix-glow for matrix theme', () => {
+      expect(getServiceIconClasses('matrix')).toContain('text-matrix-glow');
+    });
+
+    it('returns web2-primary for web2 theme', () => {
+      expect(getServiceIconClasses('web2')).toContain('text-web2-primary');
+    });
+
+    it('falls back to catppuccin-blue for unknown theme', () => {
+      expect(getServiceIconClasses('unknown')).toContain(
+        'text-catppuccin-blue'
+      );
+    });
+  });
+
+  describe('getServiceCtaBorderClasses', () => {
+    it('returns catppuccin border classes for catppuccin theme', () => {
+      expect(getServiceCtaBorderClasses('catppuccin')).toContain(
+        'border-catppuccin-blue/30'
+      );
+    });
+
+    it('returns flexoki border classes for flexoki theme', () => {
+      expect(getServiceCtaBorderClasses('flexoki')).toContain(
+        'border-flexoki-cyan/30'
+      );
+    });
+
+    it('returns matrix border classes for matrix theme', () => {
+      expect(getServiceCtaBorderClasses('matrix')).toContain(
+        'border-matrix-glow/30'
+      );
+    });
+
+    it('returns web2 border classes for web2 theme', () => {
+      expect(getServiceCtaBorderClasses('web2')).toContain(
+        'border-web2-primary/30'
+      );
+    });
+  });
+
+  describe('getServiceCtaButtonClasses', () => {
+    it('returns catppuccin button classes for catppuccin theme', () => {
+      expect(getServiceCtaButtonClasses('catppuccin')).toContain(
+        'bg-catppuccin-blue'
+      );
+    });
+
+    it('returns flexoki button classes for flexoki theme', () => {
+      expect(getServiceCtaButtonClasses('flexoki')).toContain(
+        'bg-flexoki-cyan'
+      );
+    });
+
+    it('returns matrix button classes for matrix theme', () => {
+      expect(getServiceCtaButtonClasses('matrix')).toContain('bg-matrix-glow');
+    });
+
+    it('returns web2 button classes for web2 theme', () => {
+      expect(getServiceCtaButtonClasses('web2')).toContain('bg-web2-primary');
+    });
+  });
+});

--- a/test/utils/contentful.test.js
+++ b/test/utils/contentful.test.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mock setup ──────────────────────────────────────────────────────────────
+// Must be declared before any import of the module under test so Vitest hoists it.
+
+const mockGetEntries = vi.fn();
+
+vi.mock('contentful', () => ({
+  createClient: vi.fn(() => ({
+    getEntries: mockGetEntries,
+  })),
+}));
+
+// Mock import.meta.env before the module is imported
+vi.stubEnv('VITE_CONTENTFUL_SPACE_ID', 'test-space');
+vi.stubEnv('VITE_CONTENTFUL_ACCESS_TOKEN', 'test-token');
+
+// Now import the function under test (after mocks are in place)
+const { getServices } = await import('../../src/utils/contentful');
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const makeServiceItem = ({
+  id = 'sys-id-1',
+  title = 'Test Service',
+  subtitle = 'A subtitle',
+  description = 'A description',
+  icon = 'FaCode',
+  order = 1,
+  active = true,
+} = {}) => ({
+  sys: { id },
+  fields: { title, subtitle, description, icon, order, active },
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('getServices', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a mapped array of services from Contentful', async () => {
+    const rawItem = makeServiceItem({ id: 'abc123', title: 'My Service' });
+    mockGetEntries.mockResolvedValueOnce({ items: [rawItem] });
+
+    const result = await getServices();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: 'abc123',
+      title: 'My Service',
+      subtitle: 'A subtitle',
+      description: 'A description',
+      icon: 'FaCode',
+      order: 1,
+      active: true,
+    });
+  });
+
+  it('passes correct content_type and order to getEntries', async () => {
+    mockGetEntries.mockResolvedValueOnce({ items: [] });
+
+    await getServices();
+
+    expect(mockGetEntries).toHaveBeenCalledWith({
+      content_type: 'service',
+      order: 'fields.order',
+    });
+  });
+
+  it('defaults icon to null when not provided', async () => {
+    const rawItem = makeServiceItem({ icon: undefined });
+    rawItem.fields.icon = undefined;
+    mockGetEntries.mockResolvedValueOnce({ items: [rawItem] });
+
+    const result = await getServices();
+
+    expect(result[0].icon).toBeNull();
+  });
+
+  it('defaults subtitle to empty string when not provided', async () => {
+    const rawItem = makeServiceItem({ subtitle: undefined });
+    rawItem.fields.subtitle = undefined;
+    mockGetEntries.mockResolvedValueOnce({ items: [rawItem] });
+
+    const result = await getServices();
+
+    expect(result[0].subtitle).toBe('');
+  });
+
+  it('defaults order to 0 when not provided', async () => {
+    const rawItem = makeServiceItem();
+    rawItem.fields.order = undefined;
+    mockGetEntries.mockResolvedValueOnce({ items: [rawItem] });
+
+    const result = await getServices();
+
+    expect(result[0].order).toBe(0);
+  });
+
+  it('defaults active to true when not provided', async () => {
+    const rawItem = makeServiceItem();
+    rawItem.fields.active = undefined;
+    mockGetEntries.mockResolvedValueOnce({ items: [rawItem] });
+
+    const result = await getServices();
+
+    expect(result[0].active).toBe(true);
+  });
+
+  it('returns empty array when Contentful returns no items', async () => {
+    mockGetEntries.mockResolvedValueOnce({ items: [] });
+
+    const result = await getServices();
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array and logs error on Contentful failure', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockGetEntries.mockRejectedValueOnce(new Error('API failure'));
+
+    const result = await getServices();
+
+    expect(result).toEqual([]);
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it('maps multiple items preserving all fields', async () => {
+    const items = [
+      makeServiceItem({ id: 'id1', title: 'Alpha', order: 2 }),
+      makeServiceItem({ id: 'id2', title: 'Beta', order: 1 }),
+    ];
+    mockGetEntries.mockResolvedValueOnce({ items });
+
+    const result = await getServices();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('id1');
+    expect(result[1].id).toBe('id2');
+  });
+});


### PR DESCRIPTION
## Summary
Closes #53

Integrates Contentful CMS into the Services tab, following the **Approach A — Mirror getProjects pattern** approved design.

## Changes

### `src/utils/contentful.js`
- Added `getServices()` function that fetches entries from the `service` content type
- Maps fields: `title`, `subtitle`, `description`, `icon`, `order`, `active`
- Follows same error-handling and data-mapping pattern as `getProjects()`

### `src/components/Services.jsx`
- Replaced static `services` array with dynamic `useContentful(getServices)` hook
- Added `ServiceDescription` sub-component that handles both:
  - **Rich Text** (Contentful document) via `@contentful/rich-text-react-renderer`
  - **Plain string** (fallback data)
- Services sorted by `order` and filtered by `active` flag
- Graceful fallback to hardcoded data when Contentful is unavailable
- CTA block (email + button) remains **intentionally hardcoded**
- Loading state shown while fetching

### `package.json` / `pnpm-lock.yaml`
- Added `@contentful/rich-text-react-renderer@16.1.6`

## Testing
- ✅ All 293 existing tests pass
- ✅ Production build succeeds (`pnpm build`)
- ✅ No regressions