### PR TITLE
seo: add meta description, canonical, LocalBusiness + FAQ schema, static H1

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,11 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="canonical" href="https://lux-sprwhk.xyz/" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Lux Sp4rk — Creative Tech Consultant & AI Developer based in Austin, TX. 15 years of code, background in music & film. I build AI that empowers artists." />
   <title>Lux Sp4rk | Creative Tech Consultant & AI Developer | Austin, TX</title>
+
   <!-- Primary Meta Tags -->
   <meta property="og:title" content="Lux Sp4rk | Creative Tech Consultant & AI Developer | Austin, TX" />
   <meta property="og:description"
@@ -20,9 +23,80 @@
   <meta name="twitter:description"
     content="15 years of code and a background in music & film. I build AI that empowers artists" />
   <meta name="twitter:image" content="https://lux-sp4rwhk.xyz/og-share.png" />
+
+  <!-- Schema.org LocalBusiness -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "ProfessionalService",
+    "name": "Lux Sp4rk",
+    "description": "Creative Tech Consultant & AI Developer based in Austin, TX. 15 years of code, background in music & film.",
+    "url": "https://lux-sprwhk.xyz/",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Austin",
+      "addressRegion": "TX",
+      "addressCountry": "US"
+    },
+    "geo": {
+      "@type": "GeoCoordinates",
+      "latitude": "30.2672",
+      "longitude": "-97.7431"
+    },
+    "areaServed": {
+      "@type": "City",
+      "name": "Austin"
+    },
+    "priceRange": "$$$$",
+    "image": "https://lux-sp4rwhk.xyz/og-share.png",
+    "sameAs": [
+      "https://twitter.com/luxsp4rk",
+      "https://github.com/luxsp4rk"
+    ]
+  }
+  </script>
+
+  <!-- FAQ Schema -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What services does Lux Sp4rk offer?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Lux Sp4rk offers AI development, creative tech consulting, and full-stack web/app development. Specializes in building AI-powered tools for artists and creators."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Where is Lux Sp4rk located?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Based in Austin, TX. Works with clients remotely worldwide."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What industries does Lux Sp4rk work with?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Primarily creative industries, music, film, and art communities. Also works with startups and businesses building AI-powered products."
+        }
+      }
+    ]
+  }
+  </script>
+
+  <!-- Accessible H1 style: visually hidden, visible to screen readers and crawlers -->
+  <style>#seo-h1{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)}</style>
 </head>
 
 <body>
+  <!-- Static H1 for SEO crawlers and screen readers (visually hidden) -->
+  <h1 id="seo-h1">Lux Sp4rk — Creative Tech Consultant & AI Developer in Austin, TX</h1>
   <div id="root"></div>
   <script>
     // Apply theme before React loads to prevent flicker


### PR DESCRIPTION
## Summary
Adds foundational SEO improvements to the DigiCard single-page app:

- `<link rel="canonical">` — prevents duplicate content issues
- `<meta name="description">` — plain meta description (not just OG tags)
- ProfessionalService JSON-LD schema — enables map pack eligibility for Austin, TX
- FAQ schema (3 Q\&A pairs) — enables SERP rich result expansion
- Visually-hidden static `<h1>` in `<body>` — fixes SPA crawler blind spot for H1 detection

## Testing
Use [Google Rich Results Test](https://search.google.com/test/rich-results) to validate schema markup after deploy.

Closes: (none — new work)