### PR TITLE
docs: public-facing README + theme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ A personal portfolio that earns its name — dynamic theming, CMS-driven content
 
 A React + Contentful single-page portfolio with five switchable themes, each a full visual overhaul — not just a color swap. The site content (projects, services, skills) is managed in Contentful and falls back to static data when the CMS is unavailable.
 
-**Themes:** GitHub · Dracula · Matrix · Web2 · CSS Zen Garden
+**Themes:** Catppuccin Mocha · Flexoki Light · Web2.0 · Matrix
 
 ## Features
 
-- **Dynamic theming** — five themes, switchable in real time, each with its own visual personality
+- **Dynamic theming** — four themes, switchable in real time, each a full visual overhaul
 - **Contentful CMS** — all content is editable without code; static fallback when API keys aren't present
 - **Creator integrations** — latest YouTube video, latest Instagram post, Beehiiv newsletter CTA
 - **Responsive** — works across desktop and mobile
@@ -24,13 +24,12 @@ React 18 · Vite · Tailwind CSS · CSS Modules · Contentful · Netlify
 
 ## Themes
 
-| Theme              | Vibe                                |
-| ------------------ | ----------------------------------- |
-| **GitHub**         | Dark, minimal, dev-adjacent         |
-| **Dracula**        | Purple-heavy terminal aesthetic     |
-| **Matrix**         | Green-on-black, digital rain energy |
-| **Web2**           | Clean, bright, approachable         |
-| **CSS Zen Garden** | Artistic, unconventional layout     |
+| Theme                | Vibe                                |
+| -------------------- | ----------------------------------- |
+| **Catppuccin Mocha** | Warm, dark, latte-inspired          |
+| **Flexoki Light**    | Clean, light, high-contrast         |
+| **Web2.0**           | Bright, approachable, familiar      |
+| **Matrix**           | Green-on-black, digital rain energy |
 
 ## Deployment
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,12 +23,16 @@ function App() {
     // Remove all theme classes first
     document.documentElement.classList.remove(
       'dark',
+      'github',
       'matrix',
       'light',
       'web2',
       'xmas',
       'catppuccin',
-      'flexoki'
+      'flexoki',
+      'dracula',
+      'csszen',
+      'rosepine'
     );
     // Add the current theme class
     document.documentElement.classList.add(theme);
@@ -62,7 +66,7 @@ function App() {
           <Header theme={theme} setTheme={setTheme} />
           <main
             className={clsx(
-              'bg-white dark:bg-dracula-currentLine rounded-xl overflow-hidden mb-8 md:mb-12',
+              'bg-white dark:bg-catppuccin-surface rounded-xl overflow-hidden mb-8 md:mb-12',
               'matrix:bg-matrix-terminal matrix:border matrix:border-matrix-glow/30',
               'web2:bg-web2-background web2:border-web2-border',
               'xmas:border-xmas-gold/50 xmas:border',

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -14,7 +14,7 @@ const Footer = ({ theme }) => {
     <footer
       className={clsx(
         'text-center pb-5 px-4 text-sm relative',
-        'text-github-text dark:text-dracula-foreground',
+        'text-catppuccin-text dark:text-catppuccin-text',
         'matrix:text-matrix-text',
         'catppuccin:text-catppuccin-text',
         'flexoki:text-flexoki-text'

--- a/src/components/InstagramCard.jsx
+++ b/src/components/InstagramCard.jsx
@@ -16,8 +16,7 @@ const InstagramCard = ({ post, theme }) => {
     <section
       className={clsx(
         'p-5',
-        theme !== 'web2' && 'border-t border-github-lightGray',
-        'dark:border-dracula-currentLine',
+        theme !== 'web2' && 'border-t border-catppuccin-surface',
         'matrix:border-matrix-glow',
         'matrix:shadow-lg',
         'xmas:border-xmas-gold',
@@ -29,7 +28,7 @@ const InstagramCard = ({ post, theme }) => {
         <div
           className={clsx(
             'rounded-lg overflow-hidden transition-all duration-300 hover:shadow-lg hover:-translate-y-1',
-            'bg-white dark:bg-dracula-currentLine',
+            'bg-white dark:bg-catppuccin-surface',
             'web2:bg-web2-cardBg',
             'matrix:bg-matrix-terminal matrix:border-matrix-glow matrix:shadow-lg matrix:hover:shadow-matrix-glow',
             'xmas:bg-xmas-cardBg xmas:border-xmas-gold xmas:border-2 xmas:shadow-lg xmas:hover:shadow-xmas-glow',
@@ -66,7 +65,7 @@ const InstagramCard = ({ post, theme }) => {
             <p
               className={clsx(
                 'text-sm mb-3 line-clamp-2',
-                'text-github-dark dark:text-dracula-foreground',
+                'text-catppuccin-text dark:text-catppuccin-text',
                 'web2:text-web2-text',
                 'matrix:text-matrix-text',
                 'xmas:text-xmas-white'

--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -79,7 +79,6 @@ const Profile = ({ theme }) => {
           'web2:text-4xl web2:text-web2-secondary web2:font-web2Heading',
           'matrix:text-matrix-glow',
           'flexoki:text-flexoki-text',
-          'rosepine:text-rosepine-text',
           'catppuccin:text-catppuccin-text'
         )}
       >

--- a/src/components/YouTubeCard.jsx
+++ b/src/components/YouTubeCard.jsx
@@ -56,8 +56,8 @@ const YouTubeCard = ({ video, theme }) => {
     <section
       className={clsx(
         'p-5',
-        theme !== 'web2' && 'border-t border-github-lightGray',
-        'dark:border-dracula-currentLine',
+        theme !== 'web2' && 'border-t border-catppuccin-surface',
+        'catppuccin:border-catppuccin-surface',
         'matrix:border-matrix-glow',
         'matrix:shadow-lg',
         'xmas:border-xmas-gold',
@@ -69,7 +69,7 @@ const YouTubeCard = ({ video, theme }) => {
         <div
           className={clsx(
             'rounded-lg overflow-hidden transition-all duration-300 hover:shadow-lg hover:-translate-y-1',
-            'bg-white dark:bg-dracula-currentLine',
+            'bg-white dark:bg-catppuccin-surface',
             'web2:bg-web2-cardBg',
             'matrix:bg-matrix-terminal matrix:border-matrix-glow matrix:shadow-lg matrix:hover:shadow-matrix-glow',
             'xmas:bg-xmas-cardBg xmas:border-xmas-gold xmas:border-2 xmas:shadow-lg xmas:hover:shadow-xmas-glow',

--- a/src/components/helpers/themeClassHelper.js
+++ b/src/components/helpers/themeClassHelper.js
@@ -7,15 +7,11 @@
  */
 export const getThemeClass = (styles, theme, baseClass) => {
   const themeMap = {
-    github: 'Github',
-    dark: 'Dracula',
+    catppuccin: 'Catppuccin',
+    flexoki: 'Flexoki',
     matrix: 'Matrix',
     web2: 'Web2',
     xmas: 'Xmas',
-    csszen: 'Csszen',
-    catppuccin: 'Catppuccin',
-    flexoki: 'Flexoki',
-    rosepine: 'Rosepine',
   };
 
   const themeSuffix = themeMap[theme] || 'Github';

--- a/src/utils/themeInitializer.js
+++ b/src/utils/themeInitializer.js
@@ -24,6 +24,9 @@ export function getInitialTheme({
 
   // Migrate deprecated themes
   if (
+    savedTheme === 'github' ||
+    savedTheme === 'dracula' ||
+    savedTheme === 'csszen' ||
     savedTheme === 'dark' ||
     savedTheme === 'light' ||
     savedTheme === 'rosepine'

--- a/test/components/helpers/themeClassHelper.test.js
+++ b/test/components/helpers/themeClassHelper.test.js
@@ -11,21 +11,25 @@ describe('themeClassHelper', () => {
     buttonDracula: 'Component__buttonDracula___4c5d6',
     buttonMatrix: 'Component__buttonMatrix___7e8f9',
     buttonWeb2: 'Component__buttonWeb2___0g1h2',
+    buttonCatppuccin: 'Component__buttonCatppuccin___abcd1',
+    buttonFlexoki: 'Component__buttonFlexoki___efgh2',
     cardGithub: 'Component__cardGithub___6k7l8',
     cardDracula: 'Component__cardDracula___9m0n1',
     cardMatrix: 'Component__cardMatrix___2o3p4',
     cardWeb2: 'Component__cardWeb2___5q6r7',
+    cardCatppuccin: 'Component__cardCatppuccin___ijkl3',
+    cardFlexoki: 'Component__cardFlexoki___mnop4',
   };
 
   describe('getThemeClass', () => {
-    it('should return correct class for github theme', () => {
-      const result = getThemeClass(mockStyles, 'github', 'button');
-      expect(result).toBe('Component__buttonGithub___1a2b3');
+    it('should return correct class for catppuccin theme', () => {
+      const result = getThemeClass(mockStyles, 'catppuccin', 'button');
+      expect(result).toBe('Component__buttonCatppuccin___abcd1');
     });
 
-    it('should return correct class for dark theme (maps to Dracula)', () => {
-      const result = getThemeClass(mockStyles, 'dark', 'button');
-      expect(result).toBe('Component__buttonDracula___4c5d6');
+    it('should return correct class for flexoki theme', () => {
+      const result = getThemeClass(mockStyles, 'flexoki', 'button');
+      expect(result).toBe('Component__buttonFlexoki___efgh2');
     });
 
     it('should return correct class for matrix theme', () => {
@@ -39,32 +43,32 @@ describe('themeClassHelper', () => {
     });
 
     it('should work with different base class names', () => {
-      const result = getThemeClass(mockStyles, 'github', 'card');
-      expect(result).toBe('Component__cardGithub___6k7l8');
+      const result = getThemeClass(mockStyles, 'catppuccin', 'card');
+      expect(result).toBe('Component__cardCatppuccin___ijkl3');
     });
 
-    it('should default to Github theme for unknown themes', () => {
+    it('should default to Github theme suffix for unknown themes', () => {
       const result = getThemeClass(mockStyles, 'unknown-theme', 'button');
       expect(result).toBe('Component__buttonGithub___1a2b3');
     });
 
-    it('should default to Github theme for null theme', () => {
+    it('should default to Github theme suffix for null theme', () => {
       const result = getThemeClass(mockStyles, null, 'button');
       expect(result).toBe('Component__buttonGithub___1a2b3');
     });
 
-    it('should default to Github theme for undefined theme', () => {
+    it('should default to Github theme suffix for undefined theme', () => {
       const result = getThemeClass(mockStyles, undefined, 'button');
       expect(result).toBe('Component__buttonGithub___1a2b3');
     });
 
     it('should return undefined if styles object does not contain the requested class', () => {
-      const result = getThemeClass(mockStyles, 'github', 'nonexistent');
+      const result = getThemeClass(mockStyles, 'catppuccin', 'nonexistent');
       expect(result).toBeUndefined();
     });
 
     it('should handle empty styles object', () => {
-      const result = getThemeClass({}, 'github', 'button');
+      const result = getThemeClass({}, 'catppuccin', 'button');
       expect(result).toBeUndefined();
     });
   });
@@ -77,18 +81,18 @@ describe('themeClassHelper', () => {
 
     it('should create a bound function that works correctly', () => {
       const getThemeClass = createThemeClassGetter(mockStyles);
-      const result = getThemeClass('github', 'button');
-      expect(result).toBe('Component__buttonGithub___1a2b3');
+      const result = getThemeClass('catppuccin', 'button');
+      expect(result).toBe('Component__buttonCatppuccin___abcd1');
     });
 
     it('should work with all themes through bound function', () => {
       const getThemeClass = createThemeClassGetter(mockStyles);
 
-      expect(getThemeClass('github', 'button')).toBe(
-        'Component__buttonGithub___1a2b3'
+      expect(getThemeClass('catppuccin', 'button')).toBe(
+        'Component__buttonCatppuccin___abcd1'
       );
-      expect(getThemeClass('dark', 'button')).toBe(
-        'Component__buttonDracula___4c5d6'
+      expect(getThemeClass('flexoki', 'button')).toBe(
+        'Component__buttonFlexoki___efgh2'
       );
       expect(getThemeClass('matrix', 'button')).toBe(
         'Component__buttonMatrix___7e8f9'
@@ -101,8 +105,8 @@ describe('themeClassHelper', () => {
     it('should work with different base classes through bound function', () => {
       const getThemeClass = createThemeClassGetter(mockStyles);
 
-      expect(getThemeClass('github', 'card')).toBe(
-        'Component__cardGithub___6k7l8'
+      expect(getThemeClass('flexoki', 'card')).toBe(
+        'Component__cardFlexoki___mnop4'
       );
       expect(getThemeClass('matrix', 'card')).toBe(
         'Component__cardMatrix___2o3p4'
@@ -119,11 +123,11 @@ describe('themeClassHelper', () => {
       const getThemeClass = createThemeClassGetter(mockStyles);
 
       // Multiple calls should work consistently
-      expect(getThemeClass('github', 'button')).toBe(
-        'Component__buttonGithub___1a2b3'
+      expect(getThemeClass('flexoki', 'button')).toBe(
+        'Component__buttonFlexoki___efgh2'
       );
-      expect(getThemeClass('github', 'button')).toBe(
-        'Component__buttonGithub___1a2b3'
+      expect(getThemeClass('flexoki', 'button')).toBe(
+        'Component__buttonFlexoki___efgh2'
       );
       expect(getThemeClass('matrix', 'card')).toBe(
         'Component__cardMatrix___2o3p4'
@@ -132,7 +136,7 @@ describe('themeClassHelper', () => {
 
     it('should work with empty styles object', () => {
       const getThemeClass = createThemeClassGetter({});
-      const result = getThemeClass('github', 'button');
+      const result = getThemeClass('flexoki', 'button');
       expect(result).toBeUndefined();
     });
   });
@@ -142,12 +146,12 @@ describe('themeClassHelper', () => {
       const getThemeClassBound = createThemeClassGetter(mockStyles);
 
       // Test that both functions return the same results
-      expect(getThemeClass(mockStyles, 'github', 'button')).toBe(
-        getThemeClassBound('github', 'button')
+      expect(getThemeClass(mockStyles, 'catppuccin', 'button')).toBe(
+        getThemeClassBound('catppuccin', 'button')
       );
 
-      expect(getThemeClass(mockStyles, 'dark', 'button')).toBe(
-        getThemeClassBound('dark', 'button')
+      expect(getThemeClass(mockStyles, 'flexoki', 'button')).toBe(
+        getThemeClassBound('flexoki', 'button')
       );
 
       expect(getThemeClass(mockStyles, 'matrix', 'card')).toBe(
@@ -156,8 +160,8 @@ describe('themeClassHelper', () => {
     });
 
     it('should handle all supported themes correctly', () => {
-      const supportedThemes = ['github', 'dark', 'matrix', 'web2'];
-      const expectedSuffixes = ['Github', 'Dracula', 'Matrix', 'Web2'];
+      const supportedThemes = ['catppuccin', 'flexoki', 'matrix', 'web2'];
+      const expectedSuffixes = ['Catppuccin', 'Flexoki', 'Matrix', 'Web2'];
 
       supportedThemes.forEach((theme, index) => {
         const expectedClass = `Component__button${expectedSuffixes[index]}___`;
@@ -189,8 +193,8 @@ describe('themeClassHelper', () => {
     });
 
     it('should be case sensitive for theme names', () => {
-      const result = getThemeClass(mockStyles, 'GITHUB', 'button');
-      // Should default to Github since 'GITHUB' is not in the theme map
+      const result = getThemeClass(mockStyles, 'CATPPUCCIN', 'button');
+      // Should default to Github since 'CATPPUCCIN' is not in the theme map
       expect(result).toBe('Component__buttonGithub___1a2b3');
     });
   });


### PR DESCRIPTION
Two commits:\n1. Rewrite README for public portfolio presentation (cut dev noise, lead with live link + theme table)\n2. Update themes to current lineup: Catppuccin Mocha, Flexoki Light, Web2.0, Matrix